### PR TITLE
Fix warm‑up timeout in doppler.js

### DIFF
--- a/doppler.js
+++ b/doppler.js
@@ -105,6 +105,9 @@ window.doppler = (function() {
     // There seems to be some initial "warm-up" period
     // where all frequencies are significantly louder.
     // A quick timeout will hopefully decrease that bias effect.
+    // Give the audio context a moment to stabilize before scanning.
+    // Without an explicit delay the timeout defaults to 0ms which
+    // negates the intended warm-up period.
     setTimeout(function() {
       // Optimize doppler tone
       freq = optimizeFrequency(osc, analyser, 19000, 22000);
@@ -112,7 +115,7 @@ window.doppler = (function() {
 
       clearInterval(readMicInterval);
       callback(analyser, userCallback);
-    });
+    }, 500);
   };
 
   return {


### PR DESCRIPTION
## Summary
- add comments explaining the need for a warm-up delay
- specify a 500ms delay in the `setTimeout` call so the audio context can stabilize

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68498d5556308324a754c40929a1fde9