### PR TITLE
Add Cincinnati live radar viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,14 @@ Unfortunately this doesn't work on Firefox since it doesn't seem to support the 
 * The awesome [Jasper Lu](https://github.com/jasper-lu) implemented a version of this [to android](https://github.com/jasper-lu/doppler-android). [Go check it out](https://github.com/jasper-lu/doppler-android)!
 * The wonderful [Harrison Green](https://github.com/hgarrereyn) wrote a [chrome extension](https://chrome.google.com/webstore/detail/audioscroll-extension/nknlpaccngmmdfjcbjkccfmoimehdeli?hl=en-US&gl=US) with this!
 * [Stan James](https://github.com/wanderingstan/handybird) created a wonderful flappy birds implementation with it.
+
+## Live weather radar for Cincinnati, Ohio
+
+Looking for a quick way to view current precipitation around Cincinnati? Open
+[cincinnati-radar.html](cincinnati-radar.html) in your browser while running a
+simple static file server (for example, `python -m http.server`). The page uses
+[Leaflet](https://leafletjs.com/) together with the public
+[RainViewer](https://www.rainviewer.com/api.html) radar tiles to display the
+latest live radar frame for the greater Cincinnati area. The view refreshes
+automatically every five minutes and highlights the time of the most recent
+frame at the top of the page.

--- a/cincinnati-radar.html
+++ b/cincinnati-radar.html
@@ -1,0 +1,157 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Cincinnati Live Radar</title>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+      integrity="sha384-sA+4deMzuJYqn1nVbWcv16O3MHuvb6jVWeItPxX2VINeodIZ6Tn6PvxI6RWuq7m+"
+      crossorigin=""
+    >
+    <style>
+      html, body {
+        height: 100%;
+        margin: 0;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #0b1a2a;
+        color: #f8fafc;
+      }
+
+      header {
+        padding: 1rem 1.5rem;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+        position: relative;
+        z-index: 1000;
+        background: rgba(2, 6, 23, 0.9);
+        backdrop-filter: blur(6px);
+      }
+
+      h1 {
+        margin: 0 0 0.25rem;
+        font-size: clamp(1.5rem, 3vw, 2.4rem);
+      }
+
+      p {
+        margin: 0;
+        opacity: 0.85;
+        font-size: clamp(0.9rem, 2vw, 1.05rem);
+      }
+
+      #map {
+        height: calc(100% - 96px);
+        width: 100%;
+      }
+
+      @media (max-width: 600px) {
+        #map {
+          height: calc(100% - 120px);
+        }
+      }
+
+      .leaflet-control-attribution {
+        background: rgba(2, 6, 23, 0.7);
+        color: #cbd5f5;
+      }
+
+      .leaflet-popup-content-wrapper,
+      .leaflet-control-layers {
+        background: rgba(15, 23, 42, 0.9);
+        color: #f8fafc;
+      }
+
+      .timestamp {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-feature-settings: "tnum";
+      }
+
+      .status-dot {
+        display: inline-block;
+        width: 0.75rem;
+        height: 0.75rem;
+        border-radius: 9999px;
+        background: #38bdf8;
+        box-shadow: 0 0 10px rgba(56, 189, 248, 0.7);
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Cincinnati, Ohio — Live Weather Radar</h1>
+      <p class="timestamp">
+        <span class="status-dot" aria-hidden="true"></span>
+        Last radar update: <span id="radar-timestamp">Loading…</span>
+      </p>
+    </header>
+    <main id="map" role="application" aria-label="Radar map of Cincinnati, Ohio"></main>
+
+    <script
+      src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+      integrity="sha384-pkM/HKE6nNgd6ZTUMlzUxr87hcPLZ9eczsQnUnxekxCGr0C+MEY0S8NxFNbzH+0o"
+      crossorigin=""
+    ></script>
+    <script>
+      (function() {
+        const map = L.map('map', {
+          zoomControl: true,
+          attributionControl: true
+        }).setView([39.1031, -84.5120], 8);
+
+        const baseLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+          attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        }).addTo(map);
+
+        const radarLayer = L.tileLayer('', {
+          opacity: 0.7,
+          zIndex: 100
+        }).addTo(map);
+
+        const timestampEl = document.getElementById('radar-timestamp');
+        const rainviewerApi = 'https://tilecache.rainviewer.com/api/maps.json';
+
+        async function updateRadarLayer() {
+          try {
+            timestampEl.textContent = 'Loading…';
+            const response = await fetch(rainviewerApi);
+            if (!response.ok) {
+              throw new Error('Unable to reach RainViewer API');
+            }
+
+            const timestamps = await response.json();
+            if (!Array.isArray(timestamps) || timestamps.length === 0) {
+              throw new Error('No radar frames available');
+            }
+
+            const latestTimestamp = timestamps[timestamps.length - 1];
+            const tileUrl = `https://tilecache.rainviewer.com/v2/radar/${latestTimestamp}/256/{z}/{x}/{y}/2/1_1.png`;
+            radarLayer.setUrl(tileUrl);
+
+            const updatedAt = new Date(latestTimestamp * 1000);
+            timestampEl.textContent = updatedAt.toLocaleString(undefined, {
+              hour: 'numeric',
+              minute: '2-digit',
+              month: 'short',
+              day: 'numeric'
+            });
+          } catch (error) {
+            console.error(error);
+            timestampEl.textContent = 'Unable to load radar data';
+          }
+        }
+
+        updateRadarLayer();
+        setInterval(updateRadarLayer, 5 * 60 * 1000);
+
+        const overlayControl = L.control.layers(
+          { 'OpenStreetMap': baseLayer },
+          { 'Live Radar': radarLayer },
+          { collapsed: false }
+        );
+        overlayControl.addTo(map);
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a Leaflet-based HTML page that renders the latest RainViewer radar tiles centered on Cincinnati, Ohio
- document how to view the new live radar page in the README

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cc854a7d6883249aad5eb988f81048